### PR TITLE
Restrictions for executed quotes

### DIFF
--- a/app/Http/Controllers/Admin/BillItemController.php
+++ b/app/Http/Controllers/Admin/BillItemController.php
@@ -589,6 +589,7 @@ class BillItemController extends Controller
             'type'             => $cat->type,
             'name'             => $request->name,
             'code'             => $request->code,
+            'slug'             => Str::slug($request->name),
             'msrp'             => convertMoney($request->price),
             'bill_category_id' => $cat->id,
             'description'      => 'TODO: Change Description',

--- a/app/Models/Quote.php
+++ b/app/Models/Quote.php
@@ -39,6 +39,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property int|mixed    $lead_id
  * @property mixed|string $name
  * @property mixed        $expires_on
+ * @property mixed        $status
  *
  */
 class Quote extends Model

--- a/resources/views/admin/leads/show.blade.php
+++ b/resources/views/admin/leads/show.blade.php
@@ -12,11 +12,11 @@
         </div>
         <div class="col d-flex justify-content-lg-end mt-2 mt-md-0">
             <div class="p-2 me-md-3">
-                <div><span class="h6 mb-0">${{number_format($lead->primaryMrr,2)}}</span></div>
+                <div><span class="h6 mb-0">${{moneyFormat($lead->primaryMrr)}}</span></div>
                 <small class="text-muted text-uppercase">MRR</small>
             </div>
             <div class="p-2 me-md-3">
-                <div><span class="h6 mb-0">${{number_format($lead->primaryNrc,2)}}</span></div>
+                <div><span class="h6 mb-0">${{moneyFormat($lead->primaryNrc)}}</span></div>
                 <small class="text-muted text-uppercase">NRC</small>
             </div>
             <div class="p-2 pe-lg-0">

--- a/resources/views/admin/quotes/index_lead.blade.php
+++ b/resources/views/admin/quotes/index_lead.blade.php
@@ -13,11 +13,11 @@
         </div>
         <div class="col d-flex justify-content-lg-end mt-2 mt-md-0">
             <div class="p-2 me-md-3">
-                <div><span class="h6 mb-0">${{number_format($lead->primaryMrr,2)}}</span></div>
+                <div><span class="h6 mb-0">${{moneyFormat($lead->primaryMrr)}}</span></div>
                 <small class="text-muted text-uppercase">MRR</small>
             </div>
             <div class="p-2 me-md-3">
-                <div><span class="h6 mb-0">${{number_format($lead->primaryNrc,2)}}</span></div>
+                <div><span class="h6 mb-0">${{moneyFormat($lead->primaryNrc)}}</span></div>
                 <small class="text-muted text-uppercase">NRC</small>
             </div>
             <div class="p-2 pe-lg-0">

--- a/resources/views/admin/quotes/show.blade.php
+++ b/resources/views/admin/quotes/show.blade.php
@@ -3,7 +3,7 @@
 @section('pre')
     <div class="row align-items-center">
         <div class="col-auto">
-            <h1 class="fs-5 color-900 mt-1 mb-0">#{{$quote->id}} - {{$quote->name}}</h1>
+            <h1 class="fs-5 color-900 mt-1 mb-0">#{{$quote->id}} - {{$quote->name}} ({{$quote->status}})</h1>
             <small class="text-muted">{{$quote->lead ? $quote->lead->company : $quote->account->name}} /
                 {{$quote->lead ? $quote->lead->contact : $quote->account->admin->name}}</small>
         </div>
@@ -17,7 +17,9 @@
                 <small class="text-muted text-uppercase">NRC</small>
             </div>
             <div class="p-2 pe-lg-0">
-                <div><span class="h6 mb-0">{{$quote->lead ? $quote->lead->agent->short : $quote->account->agent->short}}</span></div>
+                <div><span
+                        class="h6 mb-0">{{$quote->lead && $quote->lead->agent ? $quote->lead->agent->short : $quote->account?->agent?->short}}</span>
+                </div>
                 <small class="text-muted text-uppercase">Owner</small>
             </div>
         </div>
@@ -42,6 +44,12 @@
                            data-method="GET"
                            href="/admin/quotes/{{$quote->id}}/approve">Approve quote for sending.</a>
                     @endif
+                </div>
+            @endif
+            @if($quote->status == 'Executed')
+                <div class="alert {{bma()}}warning">
+                    <i class="fa fa-exclamation-circle"></i>
+                    This quote has been executed and is no longer able to be edited.
                 </div>
             @endif
             @include('admin.quotes.builder')


### PR DESCRIPTION
added: checks for if quote is executed and prevents all CRUD operations
fixed: moneyFormat on lead header now reflects proper mrr and nrc