### PR TITLE
Added Stale Leads Notification

### DIFF
--- a/app/Console/Commands/TaskDaily.php
+++ b/app/Console/Commands/TaskDaily.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Operations\Admin\AutoBill;
 use App\Operations\Core\BillingEngine;
 use App\Operations\Core\MetricsOperation;
+use App\Operations\Core\NotificationEngine;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Artisan;
 
@@ -34,6 +35,7 @@ class TaskDaily extends Command
         BillingEngine::dailyAccountInvoiceCheck();
         AutoBill::run();
         BillingEngine::checkPastDueInvoices();
+        NotificationEngine::run();
         Artisan::call('logic:backup');
         return 0;
     }

--- a/app/Http/Controllers/Admin/LeadController.php
+++ b/app/Http/Controllers/Admin/LeadController.php
@@ -56,6 +56,7 @@ class LeadController extends Controller
     public function update(Lead $lead, Request $request): RedirectResponse
     {
         $old = $lead->replicate();
+        $lead->update(['stale_notification_sent' => null]);
         if ($request->forecast_date)
         {
             $request->merge(['forecast_date' => Carbon::parse($request->forecast_date)]);
@@ -174,6 +175,7 @@ class LeadController extends Controller
             $disc->update(['value' => $request->value]);
             _log($disc, "Discovery Question Updated", $old);
         }
+        $lead->update(['stale_notification_sent' => null]);
         return ['success' => true];
     }
 
@@ -290,7 +292,7 @@ class LeadController extends Controller
     public function saveDiscovery(Lead $lead, Request $request): RedirectResponse
     {
         $old = $lead->replicate();
-        $lead->update(['discovery' => $request->discovery]);
+        $lead->update(['discovery' => $request->discovery, 'stale_notification_sent' => null]);
         _log($lead, "Discovery Information Updated", $old);
         return redirect()->back()->with('message', 'Discovery information saved.');
     }
@@ -315,6 +317,7 @@ class LeadController extends Controller
     {
         $old = $lead->replicate();
         $lead->setStatus($request->lead_status_id);
+        $lead->update(['stale_notification_sent' => null]);
         _log($lead, "Status Changed", $old);
         return redirect()->back()->with('message', "Lead Status Updated");
     }
@@ -326,7 +329,7 @@ class LeadController extends Controller
      */
     public function activate(Lead $lead): array
     {
-        $lead->update(['active' => 1, 'lead_status_id' => 1]);
+        $lead->update(['active' => 1, 'lead_status_id' => 1, 'stale_notification_sent' => null]);
         sysact(ActivityType::Lead, $lead->id, "reactivated lead ");
         _log($lead, "Lead was reactivated.");
         return ['callback' => "reload"];

--- a/app/Http/Controllers/Admin/SettingsController.php
+++ b/app/Http/Controllers/Admin/SettingsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Admin;
 
+use App\Enums\Core\CommKey;
 use App\Enums\Files\FileType;
 use App\Exceptions\LogicException;
 use App\Http\Controllers\Controller;
@@ -51,6 +52,7 @@ class SettingsController extends Controller
                 $setting->update(['value' => $file->id]);
             }
         }
+        CommKey::GlobalSettings->clear();
         return redirect()->back()->withMessage("Settings updated successfully.");
     }
 }

--- a/app/Http/Controllers/Sales/SalesLeadController.php
+++ b/app/Http/Controllers/Sales/SalesLeadController.php
@@ -89,14 +89,15 @@ class SalesLeadController extends Controller
             'email'   => 'required'
         ]);
         $lead->update([
-            'company' => $request->company,
-            'contact' => $request->contact,
-            'email'   => $request->email,
-            'phone'   => $request->phone,
-            'address' => $request->address,
-            'city'    => $request->city,
-            'state'   => $request->state,
-            'zip'     => $request->zip
+            'company'                 => $request->company,
+            'contact'                 => $request->contact,
+            'email'                   => $request->email,
+            'phone'                   => $request->phone,
+            'address'                 => $request->address,
+            'city'                    => $request->city,
+            'state'                   => $request->state,
+            'zip'                     => $request->zip,
+            'stale_notification_sent' => null
 
         ]);
         sysact(ActivityType::Lead, $lead->id, "updated lead ");
@@ -121,10 +122,11 @@ class SalesLeadController extends Controller
      * @param Request $request
      * @return RedirectResponse
      */
-    public function saveQuestions(Lead $lead, Request $request) : RedirectResponse
+    public function saveQuestions(Lead $lead, Request $request): RedirectResponse
     {
         if (!$lead->active) abort(404);
         if ($lead->agent_id != user()->id) abort(401);
+        $lead->update(['stale_notification_sent' => null]);
         foreach ($request->all() as $key => $val)
         {
             if (str_contains($key, "d_"))

--- a/app/Http/Livewire/Admin/ActivityComponent.php
+++ b/app/Http/Livewire/Admin/ActivityComponent.php
@@ -147,7 +147,7 @@ class ActivityComponent extends Component
             $act->save();
             if ($this->mode == 'LEAD')
             {
-                $this->lead->touch();
+                $this->lead->update(['stale_notification_sent' => null]);
             }
             if ($this->mode == 'ORDER')
             {

--- a/app/Operations/Core/NotificationEngine.php
+++ b/app/Operations/Core/NotificationEngine.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Operations\Core;
+
+use App\Enums\Core\ActivityType;
+use App\Models\Lead;
+
+/**
+ * This class will check for any daily notifications that need to be sent out to either admins
+ * or sales agents. This should be run during the TaskDaily routine.
+ */
+class NotificationEngine
+{
+    /**
+     * Main entry point to run all notification checks.
+     * @return void
+     */
+    static public function run() : void
+    {
+        $x = new self;
+        $x->checkStaleLeads();
+    }
+
+
+    /**
+     * Check for stale leads, and email the agent assigned.
+     * @return void
+     */
+    public function checkStaleLeads() : void
+    {
+        foreach(Lead::where('active', true)->get() as $lead)
+        {
+            if ($lead->requires_update && !$lead->stale_notification_sent) // Lead is stale
+            {
+                if (!$lead->agent) continue; // No agent to email
+                template('sales.staleLead', $lead->agent, [$lead]);
+                $lead->timestamps = false; // A notification should not be considered an update.
+                $lead->stale_notification_sent = now();
+                $lead->save();
+                sysact(ActivityType::Lead, $lead->id, "sent a stale lead notification to {$lead->agent->name}");
+                _log($lead, "Stale notification sent to agent.");
+            }
+        }
+    }
+
+}

--- a/database/migrations/2023_02_21_130606_add_sales_email_category.php
+++ b/database/migrations/2023_02_21_130606_add_sales_email_category.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        \App\Models\EmailTemplateCategory::create([
+           'name' => "Sales"
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2023_02_21_131437_add_stale_notification_to_leads.php
+++ b/database/migrations/2023_02_21_131437_add_stale_notification_to_leads.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            $table->timestamp('stale_notification_sent')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('leads', function (Blueprint $table) {
+            $table->dropColumn('stale_notification_sent');
+        });
+    }
+};

--- a/database/seeders/EmailSeeder.php
+++ b/database/seeders/EmailSeeder.php
@@ -11,6 +11,8 @@ class EmailSeeder extends Seeder
     const CAT_FINANCE = 1;  // Quotes, Invoices, any Billing related emails
     const CAT_LEADS   = 2;  // Leads/Discovery/Updates,etc
     const CAT_ACCOUNT = 3;  // Account Information
+    const CAT_SALES   = 4;  // Sales/Affiliate Emails
+
 
     /**
      * Run the database seeds.
@@ -48,10 +50,6 @@ class EmailSeeder extends Seeder
             'When a MSA has been signed.',
             'Your {setting.brand-name} Signed Agreement Copy');
 
-
-        $this->buildEmail('lead.discovery', self::CAT_LEADS, 'Discovery Request',
-            'Sent to lead to obtain information for creating a quote.',
-            'Hey {lead.first}, We need some information from you!', 'SimpleLead');
 
         $this->buildEmail('account.welcome', self::CAT_ACCOUNT, 'Welcome Email', 'Sent when a lead becomes an account',
             'Welcome to {setting.brand-name}!');
@@ -146,6 +144,11 @@ class EmailSeeder extends Seeder
         $this->buildEmail('agent.batchPaid', self::CAT_FINANCE, 'Agent Commission Batch Paid',
             'Email sent when a payment has been sent to the sales agent.',
             'Payment Sent for Commission Batch #{commissionBatch.id}');
+
+        $this->buildEmail('sales.staleLead', self::CAT_SALES, 'Stale Lead',
+            'Sent to sales agents when a lead has gone stale',
+            '[{lead.company}] Lead has gone stale, Please Update');
+
 
         EmailTemplate::placeholders();
 

--- a/resources/views/template_holders/sales-staleLead.blade.php
+++ b/resources/views/template_holders/sales-staleLead.blade.php
@@ -1,0 +1,5 @@
+<b>{lead.company}</b> is currently an active lead assigned to you.
+
+Leads that go <b>{setting.leads-aging} days</b> without an update are considered "stale" and require an update. If this lead is still active, please login to your dashboard, navigate to the lead, select "Discovery" and add either a comment or update the discovery section to clear this alert.
+
+By doing this, you will reset the timer. If this lead is no longer viable, please add a note and close the lead as <i>Lost</i>.


### PR DESCRIPTION
added: migration for storing date when a stale notification was last sent
added: null stale notification when updated by admin or sales agent
added: sales email category
added: email template for lead gone stale
added: notification engine to task daily
fixed: cleared settings cache when a setting is updated from admin